### PR TITLE
Fix for Resque namespace error

### DIFF
--- a/lib/rpm_contrib/instrumentation/resque.rb
+++ b/lib/rpm_contrib/instrumentation/resque.rb
@@ -24,7 +24,7 @@ module RPMContrib
       end
 
       ::Resque::Job.class_eval do
-        include Resque::Plugins::NewRelicInstrumentation
+        include ::Resque::Plugins::NewRelicInstrumentation
       end
     end
   end


### PR DESCRIPTION
The Resque instrumentation caused an exception due to an incorrect namespace:

uninitialized constant RPMContrib::Instrumentation::Resque::Plugins

Looks like my commit fixes it. I tested it in my project, but somebody should probably write some tests for the Resque stuff.
