### PR TITLE
Detailed MongoDB/Mongoid instrumentation

### DIFF
--- a/lib/rpm_contrib/instrumentation/mongo.rb
+++ b/lib/rpm_contrib/instrumentation/mongo.rb
@@ -32,6 +32,9 @@ DependencyDetection.defer do
       alias_method :instrument_without_newrelic_trace, :instrument
       alias_method :instrument, :instrument_with_newrelic_trace
     end
+    class Mongo::Collection; include Mongo::Logging; end
+    class Mongo::Connection; include Mongo::Logging; end
+    class Mongo::Cursor; include Mongo::Logging; end
 
     # cursor refresh is not currently instrumented in mongo driver, so not picked up by above - have to add our own here
     ::Mongo::Cursor.class_eval do

--- a/lib/rpm_contrib/instrumentation/mongoid.rb
+++ b/lib/rpm_contrib/instrumentation/mongoid.rb
@@ -1,0 +1,21 @@
+DependencyDetection.defer do
+  @name = :mongoid
+
+  depends_on do
+    defined?(::Mongoid) and not NewRelic::Control.instance['disable_mongoid']
+  end
+
+  executes do
+    NewRelic::Agent.logger.debug 'Installing Mongoid instrumentation'
+  end
+
+  executes do
+    Mongoid::Collection.class_eval do
+      include NewRelic::Agent::MethodTracer
+
+      (Mongoid::Collections::Operations::ALL - [:<<, :[]]).each do |method|
+        add_method_tracer method, "ActiveRecord/\#{@klass}/#{method}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch combines @bensymonds' wonderful MongoDB patch with Mongoid instrumentation to provide detailed transaction traces.

Despite instrumenting under the `ActiveRecord` and `SQL` metric categories, I'm still not seeing the Database section on my overall RPM graph show up. What should I do to get that?
