### PR TITLE
Fixed constant defined issue when aws-s3 library is not loaded but aws-sdk is

### DIFF
--- a/lib/rpm_contrib/instrumentation/aws.rb
+++ b/lib/rpm_contrib/instrumentation/aws.rb
@@ -3,7 +3,7 @@ DependencyDetection.defer do
   @name = :aws
   
   depends_on do
-    defined?(::AWS::S3) && !NewRelic::Control.instance['disable_aws-s3']
+    defined?(::AWS::S3::Connection) && !NewRelic::Control.instance['disable_aws-s3']
   end
   
   executes do


### PR DESCRIPTION
This is just a more granular check for the AWS::S3 library to not cause a failure when aws-s3 library is not loaded but aws-sdk library is which does define AWS::S3.
