### PR TITLE
mongoid instrument only support mongoid 2.x

### DIFF
--- a/lib/rpm_contrib/instrumentation/mongoid.rb
+++ b/lib/rpm_contrib/instrumentation/mongoid.rb
@@ -2,7 +2,7 @@ DependencyDetection.defer do
   @name = :mongoid
 
   depends_on do
-    defined?(::Mongoid) and not NewRelic::Control.instance['disable_mongoid']
+    defined?(::Mongoid) && Mongoid::VERSION.to_i == 2 && !NewRelic::Control.instance['disable_mongoid']
   end
 
   executes do


### PR DESCRIPTION
Mongoid::Collection was removed in mongoid 3.x, so we should check version of mongoid before adding the instrument
