### PR TITLE
Remove duplicate dependencies in gemspec

### DIFF
--- a/rpm_contrib.gemspec
+++ b/rpm_contrib.gemspec
@@ -64,13 +64,10 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<newrelic_rpm>, [">= 3.1.1"])
-      s.add_runtime_dependency(%q<newrelic_rpm>, [">= 3.1.1"])
     else
-      s.add_dependency(%q<newrelic_rpm>, [">= 3.1.1"])
       s.add_dependency(%q<newrelic_rpm>, [">= 3.1.1"])
     end
   else
-    s.add_dependency(%q<newrelic_rpm>, [">= 3.1.1"])
     s.add_dependency(%q<newrelic_rpm>, [">= 3.1.1"])
   end
 end


### PR DESCRIPTION
Hi,

Any reason why these lines are doubled in the `.gemspec`? This commit removes the duplicates in the hope that it would not break anything.

Yours,
Amir
