### PR TITLE
Use Addressable for parsing the Curb host if defined

### DIFF
--- a/lib/rpm_contrib/instrumentation/curb.rb
+++ b/lib/rpm_contrib/instrumentation/curb.rb
@@ -11,8 +11,9 @@ DependencyDetection.defer do
   
   executes do
     ::Curl::Easy.class_eval do
+      URI_CLASS = defined?(::Addressable) ? ::Addressable::URI : URI
       def host
-        URI.parse(self.url).host
+        self.url.respond_to?(:host) ? self.url.host : URI_CLASS.parse(self.url).host
       end
 
       # TODO: http, http_delete, http_get, http_post, http_head, http_put


### PR DESCRIPTION
Fixes parsing urls that URI does not support (non-ascii, amazonaws, etc).

This is a patch by Boris ([reist/rpm_contrib/2.1.11patched](https://github.com/reist/rpm_contrib/tree/2.1.11patched)), which I have amended just a little.

Thanks,
Amir
